### PR TITLE
Hardening Firebase Rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -14,11 +14,9 @@
     },
     "v1": {
       "users": {
-        ".write": "auth !== null && auth.provider === 'github'",
         ".read": "auth !== null && auth.provider === 'github'",
         "$uid": {
-          ".read": "auth != null && auth.uid == $uid",
-          ".write": "auth != null && auth.uid == $uid"
+          ".write": "auth != null && auth.provider === 'github' && auth.uid == $uid"
         }
       },
       "signups": {


### PR DESCRIPTION
Fixes #41
You can view the security issue in [this report](https://noless.io/report/-L7Ob5_5b0EJxxCBq1yB/128310f1-7d10-4bc0-9f76-a1b14cc45387).

## Solution

I removed the rule `".write": "auth !== null && auth.provider === 'github'"` from `v1/users`, and hardened the write rule under `v1/users/$uid` so a user can only write to its own uid.

In addition, I removed the read rule from `/v1/users/$uid`, since it was useless because of the `".read": "auth !== null && auth.provider === 'github'"` under `/v1/users`.

From what I saw, the current functionality needs to read all the users, therefore I left it permissive rule. 

**Note:** I didn't removed the problem from the old API, in order not to break anything.

An analysis on the fixed rules can be [seen here](https://noless.io/report/-L7Obymyy4YWjHxtt6Ux/95ff53c0-de99-4dc3-9def-63711b82bb2d).